### PR TITLE
Add marv missing dependencies for postgres package.

### DIFF
--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     <% if (components.indexOf('express') > -1) { %>    "systemic-express": "^1.1.0",<% } %>
     <% if (components.indexOf('mongo') > -1) { %>    "systemic-mongodb": "^1.0.4",<% } %>
-    <% if (components.indexOf('postgres') > -1) { %>    "systemic-pg": "^1.2.0",<% } %>
+    <% if (components.indexOf('postgres') > -1) { %>    "systemic-pg": "^1.2.0", "marv": "^2.2.0", "marv-pg-driver": "^2.1.1",<% } %>
     <% if (components.indexOf('redis') > -1) { %>    "systemic-redis": "^1.0.2",<% } %>
     "ramda": "0.25.0",
     "on-headers": "^1.0.1",


### PR DESCRIPTION
By default the marv packages are missing in the generator.