### PR TITLE
feat: adds author and contact email as template inputs

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,6 +25,18 @@ module.exports = class extends Generator {
 			name: 'description',
 			message: 'A brief description',
 			default: '',
+		},
+		{
+			type: 'input',
+			name: 'author',
+			message: 'The service author',
+			default: '',
+		},
+		{
+			type: 'input',
+			name: 'email',
+			message: 'The service author contact email',
+			default: '',
 		}];
 
 		return this.prompt(prompts).then(props => {

--- a/generators/app/templates/docs/syncapi.yaml
+++ b/generators/app/templates/docs/syncapi.yaml
@@ -5,9 +5,8 @@ info:
   description: Documentation for <%= name %> synchronous api
   termsOfService: http://swagger.io/terms/
   contact:
-    name: Swagger API Team
-    email: apiteam@swagger.io
-    url: http://swagger.io
+    name: <%= author %>
+    email: <%= email %>
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -2,6 +2,10 @@
   "name": "<%= name %>",
   "version": "0.0.1",
   "description": "<%= description %>",
+  "author": {
+    "name": "<%= author %>",
+    "email": "<%= email %>"
+  },
   "main": "index.js",
   "scripts": {
     "local": "SERVICE_ENV=local node index.js",


### PR DESCRIPTION
these 2 new inputs are going to be used to populate both:
- package.json
- swagger syncapi docs