### PR TITLE
feat: center logger message level and pad on both sides

### DIFF
--- a/generators/app/templates/lib/components/logging/console.js
+++ b/generators/app/templates/lib/components/logging/console.js
@@ -25,8 +25,8 @@ module.exports = () => {
 		const details = R.pluck(event, []);
 		const data = R.merge(event, {
 			displayTracer: R.has('tracer', event) ? event.tracer.substr(0, 6) : '|',
-			displayLevel: event.level.toUpperCase().padStart(event.level.length + Math.floor((8 - event.level.length) / 2), ' ')
-				.padEnd(8, ' '),
+			displayLevel: event.level.toUpperCase().padStart(event.level.length + Math.floor((6 - event.level.length) / 2), ' ')
+				.padEnd(6, ' '),
 			details: Object.keys(details).length ? `\n ${JSON.stringify(details, null, 2)}` : '',
 			errorMessage:
 				event.error &&

--- a/generators/app/templates/lib/components/logging/console.js
+++ b/generators/app/templates/lib/components/logging/console.js
@@ -25,7 +25,8 @@ module.exports = () => {
 		const details = R.pluck(event, []);
 		const data = R.merge(event, {
 			displayTracer: R.has('tracer', event) ? event.tracer.substr(0, 6) : '|',
-			displayLevel: event.level.toUpperCase(),
+			displayLevel: event.level.toUpperCase().padStart(event.level.length + Math.floor((8 - event.level.length) / 2), ' ')
+				.padEnd(8, ' '),
 			details: Object.keys(details).length ? `\n ${JSON.stringify(details, null, 2)}` : '',
 			errorMessage:
 				event.error &&


### PR DESCRIPTION
This change is intended to assist in the reading of service logs by centering and maintaining a fixed width at the beginning of the log lines.

### Before
```
2020-05-21T06:36:52.208Z | INFO [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:36:52.210Z | WARN [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:36:52.212Z | DEBUG [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:36:52.214Z | ERROR [systemic-playground] | wubba lubba dub dub 
```

### After
```
2020-05-21T06:30:23.149Z |   INFO [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:30:23.151Z |   WARN [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:30:23.154Z |  DEBUG [systemic-playground] | wubba lubba dub dub 
2020-05-21T06:30:23.155Z |  ERROR [systemic-playground] | wubba lubba dub dub 
```