### PR TITLE
feat: adds helmet to secure rest endpoints

### DIFF
--- a/generators/app/templates/lib/components/routes/admin-routes.js
+++ b/generators/app/templates/lib/components/routes/admin-routes.js
@@ -1,4 +1,4 @@
-const helmet = require("helmet");
+const helmet = require('helmet');
 const bodyParser = require('body-parser');
 const validator = require('swagger-endpoint-validator');
 

--- a/generators/app/templates/lib/components/routes/admin-routes.js
+++ b/generators/app/templates/lib/components/routes/admin-routes.js
@@ -1,3 +1,4 @@
+const helmet = require("helmet");
 const bodyParser = require('body-parser');
 const validator = require('swagger-endpoint-validator');
 
@@ -5,6 +6,7 @@ module.exports = () => {
 	const start = async ({ manifest = {}, app, config }) => {
 		app.use(bodyParser.urlencoded({ extended: true }));
 		app.use(bodyParser.json());
+		app.use(helmet());
 
 		await validator.init(app, config.swaggerValidator);
 

--- a/generators/app/templates/root/_README.md
+++ b/generators/app/templates/root/_README.md
@@ -68,7 +68,7 @@ The component in charge of mixing and set up the configuration defined into the 
 - prod
 
 ### __routes__
-The component in charge of specifiyng the routes to be exposed by the express component.
+The component in charge of specifiyng the routes to be exposed by the express component. Note that the the express endpoints are secured thanks to [helmet](https://helmetjs.github.io/).
 
 ### __routes.admin__
 The admin api sub-component in charge of exposing the `/__/manifest` endpoint.

--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -54,6 +54,7 @@
     <%_ if (showcase) { -%>
     "error-handler-module": "^1.0.3",
     <%_ } -%>
+    "helmet": "^4.1.1",
     "hogan.js": "^3.0.2",
     "make-manifest": "^1.0.1",
     "optimist": "^0.6.1",

--- a/generators/app/templates/test/service.test.js
+++ b/generators/app/templates/test/service.test.js
@@ -39,6 +39,11 @@ describe('Service Tests', () => {
 			.expect(200)
 			.then(response => {
 				expect(response.headers['content-type']).to.equal('application/json; charset=utf-8');
+				expect(response.headers['x-frame-options']).to.equal('SAMEORIGIN');
+				expect(response.headers['x-download-options']).to.equal('noopen');
+				expect(response.headers['x-dns-prefetch-control']).to.equal('off');
+				expect(response.headers['x-content-type-options']).to.equal('nosniff');
+				expect(response.headers['strict-transport-security']).to.equal('max-age=15552000; includeSubDomains');
 			}));
 	
 	<%_ if (showcase) { -%>


### PR DESCRIPTION
## Description

Adds [helmet](https://helmetjs.github.io/) in order secure [express](https://expressjs.com/) REST endpoints by setting various HTTP headers. The newly added headers are checked in the provided test suite.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other (if none of the other choices apply)

## How to review this PR

1. Pull the latest changes
2. Run `yo systemic` in order to generate a new service and then run `npm run test`
3. Run `yo systemic --showcase` in order to generate a new service and then run `npm run infra-up` + `npm run test`

## Issues solved by this PR

Closes #56 
